### PR TITLE
Recursively seek for subfields in aliases

### DIFF
--- a/massmailer/models.py
+++ b/massmailer/models.py
@@ -20,7 +20,7 @@ from django.utils.translation import ugettext_lazy as _
 from functools import reduce
 
 from massmailer.query_parser import QueryParser, ParseError
-from massmailer.utils import filters as mfilters
+from massmailer.utils import get_attr_rec, get_field_rec, filters as mfilters
 from massmailer.utils.db import ConditionalSum, CaseMapping
 from massmailer.utils.sandbox import SandboxedModelEnvironment
 
@@ -208,7 +208,7 @@ class Query(models.Model):
                 )
             user_field = result.aliases['user']
             try:
-                if qs.model._meta.get_field(user_field).related_model != User:
+                if get_field_rec(qs.model, user_field) != User:
                     raise ParseError(
                         _("%(label)s.%(field)s is not %(model)s")
                         % {
@@ -333,7 +333,7 @@ class Batch(models.Model):
         if result.queryset.model is get_user_model():
             user_getter = lambda object: object
         else:
-            user_getter = lambda object: getattr(
+            user_getter = lambda object: get_attr_rec(
                 object, result.aliases['user']
             )
 
@@ -341,7 +341,7 @@ class Batch(models.Model):
 
         for object in queryset:
             context = {
-                alias: getattr(object, field)
+                alias: get_attr_rec(object, field)
                 for alias, field in result.aliases.items()
             }
             context[result.model_name] = object

--- a/massmailer/utils/__init__.py
+++ b/massmailer/utils/__init__.py
@@ -51,3 +51,25 @@ class JinjaEscapeExtension(Extension):
     def extendMarkdown(self, md):
         md.preprocessors.add('jinja-pre', Pre(self), '_begin')
         md.postprocessors.add('jinja-post', Post(self), '_end')
+
+
+def get_attr_rec(item, field):
+    '''
+    Same as getattr(item, field) but behaves recursivelly with the
+    field__subfield syntax.
+    '''
+    for key in field.split('__'):
+        item = getattr(item, key)
+
+    return item
+
+
+def get_field_rec(model, field):
+    '''
+    Select a field from an django model, behaves recursivelly with the
+    field__subfield syntax.
+    '''
+    for key in field.split('__'):
+        model = model._meta.get_field(key).related_model
+
+    return model

--- a/massmailer/views.py
+++ b/massmailer/views.py
@@ -38,7 +38,7 @@ import massmailer.forms
 import massmailer.models
 import massmailer.tasks
 from massmailer.query_parser import QueryParser
-from massmailer.utils import JinjaEscapeExtension
+from massmailer.utils import JinjaEscapeExtension, get_attr_rec
 
 
 class MailerAdminMixin(UserPassesTestMixin):
@@ -158,7 +158,7 @@ class TemplatePreviewView(PermissionRequiredMixin, MailerAdminMixin, View):
         try:
             object = qs[page]
             context = {
-                alias: getattr(object, field)
+                alias: get_attr_rec(object, field)
                 for alias, field in results.aliases.items()
             }
             context[results.model_name] = object
@@ -289,7 +289,7 @@ class QueryPreviewView(PermissionRequiredMixin, MailerAdminMixin, View):
                 obj = qs[page]
                 instance = {result.model_name: self.serialize(obj)}
                 for name, field in result.aliases.items():
-                    serialized = self.serialize(getattr(obj, field))
+                    serialized = self.serialize(get_attr_rec(obj, field))
                     if serialized:
                         instance[name] = serialized
 


### PR DESCRIPTION
As both `getattr` and [`_meta.get_field`](https://docs.djangoproject.com/en/3.0/ref/models/meta/#django.db.models.options.Options.get_field) don't handle sub-fields, it was not possible to define an alias on a subfield for a query.

For example with the following model:

```python
class Applicant(models.Model):
    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
    year = models.IntegerField()


class EventWish(models.Model):
    applicant = models.ForeignKey(Applicant, on_delete=models.CASCADE)
    event = models.TextField()

```

master|alias-subkeys 
-|-
![Screenshot_2020-02-04 New query – django-massmailer(1)](https://user-images.githubusercontent.com/1173464/73733098-9fed6800-473b-11ea-80b7-77c48d17e639.png)|![Screenshot_2020-02-04 New query – django-massmailer](https://user-images.githubusercontent.com/1173464/73733113-a67bdf80-473b-11ea-8748-3a09da91bd1e.png)

We can still properly access aliases and subkeys:

![Screenshot_2020-02-04 New template – django-massmailer](https://user-images.githubusercontent.com/1173464/73733494-60734b80-473c-11ea-9e94-afa7b9b521f4.png)

