### PR TITLE
order results in previews

### DIFF
--- a/massmailer/views.py
+++ b/massmailer/views.py
@@ -147,7 +147,7 @@ class TemplatePreviewView(PermissionRequiredMixin, MailerAdminMixin, View):
             template.html_body = html
 
         results, user_qs = query.get_results()
-        qs = results.queryset
+        qs = results.queryset.order_by('pk')
         count = qs.count()
         user_count = user_qs.count()
         data['query'] = {
@@ -281,7 +281,7 @@ class QueryPreviewView(PermissionRequiredMixin, MailerAdminMixin, View):
         try:
             # run the query
             result, user_qs = massmailer.models.Query.execute(query)
-            qs = result.queryset
+            qs = result.queryset.order_by('pk')
             count = qs.count()
             user_count = user_qs.count()
             instance = None


### PR DESCRIPTION
Order the results for Template and Query previews. Otherwise query results can be ordered differently at each page load and querying for the "nth page" doesn't make any sense (we can get the same item in separate pages).

Note that this was already done during the mails construction step: https://github.com/prologin/django-massmailer/blob/c231084192228dda31c4999f4e9a77fda56ad808/massmailer/models.py#L331

There might be some nice factorization to do, maybe it is worth of an issue ?