### PR TITLE
do not load parent extra scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ Greetings, {{ user.get_full_name().strip().title() }}!
 {% if user.is_staff %}With great power comes great responsibility.{% endif %}
 ```
 
+### Use your how base template
+
+If you want to use massmailer inside of your own template you can create a base
+template in `mysite/mysite/templates/massmailer/base.html`:
+
+```jinja
+{% extends "mysite/base.html" %}
+
+{# Just reuse my main base.html #}
+```
+
+Note that massmailer will try to load jQuery and bootstrap, which will raise
+issues if you also happen to use it. To avoid this you should load
+corresponding JS files inside a `massmailer_extra_script` block:
+
+```jinja
+{% block massmailer_extra_script %}
+  <script src="{% static 'path/to/jquery.min.js' %}"></script>
+  <script src="{% static 'path/to/bootstrap.min.js' %}"></script>
+{% endblock %}
+```
+
 #### Template filters
 
 In addition to the Jinja2 [builtin

--- a/massmailer/templates/massmailer/base.html
+++ b/massmailer/templates/massmailer/base.html
@@ -38,6 +38,6 @@
     </div>
   </footer>
 
-  {% block extra_script %}{% endblock %}
+  {% block massmailer_extra_script %}{% endblock %}
 </body>
 </html>

--- a/massmailer/templates/massmailer/common.html
+++ b/massmailer/templates/massmailer/common.html
@@ -13,8 +13,7 @@
   {% breadcrumb_for 'massmailer:dashboard' %}Mailing{% endbreadcrumb_for %}
 {% endblock %}
 
-{% block extra_script %}
-  {{ block.super }}
+{% block massmailer_extra_script %}
   <script src="{% static 'massmailer/vendor/jquery.min.js' %}"></script>
   <script src="{% static 'massmailer/vendor/bootstrap.min.js' %}"></script>
 {% endblock %}

--- a/massmailer/templates/massmailer/query/details.html
+++ b/massmailer/templates/massmailer/query/details.html
@@ -165,7 +165,7 @@ alias some_name = .some_field</pre>
 
 {% endblock %}
 
-{% block extra_script %}
+{% block massmailer_extra_script %}
   {{ block.super }}
   <script type="text/javascript">
     var PREVIEW_URL = '{% url 'massmailer:query:preview' %}';

--- a/massmailer/templates/massmailer/template/details.html
+++ b/massmailer/templates/massmailer/template/details.html
@@ -129,7 +129,7 @@
 
 {% endblock %}
 
-{% block extra_script %}
+{% block massmailer_extra_script %}
   {{ block.super }}
   <script type="text/javascript">
     var PREVIEW_URL = '{% url 'massmailer:template:preview' %}';


### PR DESCRIPTION
Rename the `extra_script` section into `massmailer_extra_script` and don't load parent definition of this block anymore.

This helps not to load bootstrap and jquery a second time if the project including this library already use them.

This feels quite hacky and dirty, do you see a better way to do that ? :/