### PR TITLE
Fix issue #18 (module 'jinja2' has no attribute 'contextfilter')

### DIFF
--- a/massmailer/utils/filters.py
+++ b/massmailer/utils/filters.py
@@ -8,19 +8,19 @@ def get_locale(ctx):
     return babel.Locale.parse(language_code, sep='-')
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_datetime(ctx, date, format='full'):
     locale = get_locale(ctx)
     return babel.dates.format_datetime(date, format=format, locale=locale)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_date(ctx, date, format='full'):
     locale = get_locale(ctx)
     return babel.dates.format_date(date, format=format, locale=locale)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_time(ctx, date, format='full'):
     locale = get_locale(ctx)
     return babel.dates.format_time(date, format=format, locale=locale)


### PR DESCRIPTION
Fixes issue #18, contextfilter was deprecated and removed in newer jinja2 versions.
This function was renamed to pass_context.

Works with prologin/site(8e6af63).